### PR TITLE
node profile package as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "dependencies": {
     "docco": "~0.4.0",
     "byline": "~2.0.3",
-    "nodeunit": "~0.7.4",
+    "nodeunit": "~0.7.4"
+  },
+  "devDependencies": {
     "profile": "~0.0.10"
   },
-  "devDependencies": {},
+
   "scripts": {
     "test": "./wat test"
   }


### PR DESCRIPTION
Using eep-js in production can be made easier by marking the node profile package as a dev dependency. 
